### PR TITLE
rename file for metrics and model vision

### DIFF
--- a/pastis/interface/main.py
+++ b/pastis/interface/main.py
@@ -37,5 +37,5 @@ def train_unet_clstm():
     save_results(metrics)
 
 if __name__ == '__main__':
-    train_baseline()
-    #train_unet_clstm()
+    #train_baseline()
+    train_unet_clstm()

--- a/pastis/ml_logic/models/unet_baseline/baseline_model.py
+++ b/pastis/ml_logic/models/unet_baseline/baseline_model.py
@@ -3,6 +3,7 @@ import time
 import numpy as np
 
 from tensorflow import keras
+from statistics import mean
 
 from keras.models import Model
 from keras.layers import Input, Conv2D, Dropout
@@ -14,6 +15,7 @@ from keras.callbacks import EarlyStopping, ModelCheckpoint, CSVLogger
 from pastis.params import SAVE_PATH, NUM_CLASSES
 from pastis.ml_logic.models.metrics import m_iou, _iou
 from pastis.ml_logic.models.unet_baseline.layers import up_block,down_block,bottleneck
+from pastis.ml_logic.utils import rename_file
 
 
 # ----- UNET BASELINE MODEL -----
@@ -26,6 +28,7 @@ class Unet_baseline():
     def __init__(self):
         self.init_model()
         self.compile_model()
+        self.name='Unet_baseline'
 
     def init_model(self,input_shape:tuple=(128,128,10), dropout:float=0) -> Model:
         '''U-net model architecture has 3 parts :
@@ -107,7 +110,7 @@ class Unet_baseline():
         """
 
         timestamp = time.strftime("%Y%m%d-%H%M%S")
-        params_path = os.path.join(SAVE_PATH, "params", timestamp + "modcheck")
+        params_path = os.path.join(SAVE_PATH, "params", timestamp + "_modcheck")
         csv_path = os.path.join(SAVE_PATH, "csv", timestamp + "_csvlog.csv")
 
         es = EarlyStopping(
@@ -132,6 +135,10 @@ class Unet_baseline():
             callbacks=[es,mc,csvlog],
             verbose=1
         )
+        #rename file with accuracy and model name
+        metrics = str(round(mean(self.history.history['acc']),3))
+        rename_file(params_path, metrics ,self.model.name)
+        rename_file(csv_path, metrics ,self.model.name)
 
         print('-'*50)
         print(f"✅ Model trained with :\n\

--- a/pastis/ml_logic/models/unet_conv_lstm/unet_convlstm.py
+++ b/pastis/ml_logic/models/unet_conv_lstm/unet_convlstm.py
@@ -4,6 +4,7 @@ import tensorflow as keras
 import time
 import os
 import numpy as np
+from statistics import mean
 
 from keras import layers, optimizers, Input
 from keras.layers import *
@@ -14,12 +15,14 @@ from keras.callbacks import EarlyStopping, ModelCheckpoint, CSVLogger
 from pastis.ml_logic.models.unet_conv_lstm.layers_convlstm import _encoder, _decoder
 from pastis.ml_logic.models.metrics import m_iou
 from pastis.params import SAVE_PATH, NUM_CLASSES
+from pastis.ml_logic.utils import rename_file
 
 class UNetConvLSTMModel:
     def __init__(self, num_classes=20):
         self.num_classes = num_classes
         self.build_model()
         self.compile_model()
+        self.name='UNetConvLSTMModel'
         # self.model = self.build_model()
         # self.model.compile()
 
@@ -114,6 +117,10 @@ class UNetConvLSTMModel:
             callbacks=[es,mc,csvlog],
             verbose=1
         )
+        #rename file with accuracy and model name
+        metrics = str(round(mean(self.history.history['acc']),3))
+        rename_file(params_path, metrics ,self.model.name)
+        rename_file(csv_path, metrics ,self.model.name)
 
         print('-'*50)
         print(f"✅ Model trained with :\n\

--- a/pastis/ml_logic/utils.py
+++ b/pastis/ml_logic/utils.py
@@ -21,6 +21,17 @@ def load_geojson() -> gpd:
 
 METADATA = load_geojson()
 
+def rename_file (path_file:str, metrics:str, model_name:str)->str:
+    ''' function to rename the outputs_model files, to classify them:
+    from : timestamp_
+    to :   metrics_modelname_timestamp_'''
+    base = path_file.split('/')[:-1]
+    base='/'.join(base)+'/'
+    end = path_file.split('/')[-1]
+
+    rename = base+metrics+'_'+model_name+'_'+end
+    os.rename(path_file, rename)
+
 
 def index_date(patch_id: int, mono_date: str = '2019-09-01') -> int:
     """Obtain the index of the nearest date of S2 satelite Time Series

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ matplotlib
 seaborn
 # data-science
 scikit-learn
-tensorflow
+tensorflow==2.10
 geopandas


### PR DESCRIPTION
    add a function to rename the outputs_model files, to classify them:
    from : timestamp_
    to :   metrics_modelname_timestamp_